### PR TITLE
Create test Validate Payment Summary in Payment page

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -13,6 +13,7 @@ import { defineConfig, devices } from '@playwright/test';
  * @see https://playwright.dev/docs/test-configuration
  */
 export default defineConfig({
+  timeout: 60000, // Sets the default test timeout to 60 seconds
   testDir: './tests',
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/tests/data/orders.data.js
+++ b/tests/data/orders.data.js
@@ -3,5 +3,11 @@ export const ORDERSLOCATORS = {
     //Labels
     labels: {
         pageTitle: 'Purchase Orders'
+    },
+
+    //Table list elements
+    table: {
+        list: 'orders-list',
+        listItem: 'listitem',     
     }
 }

--- a/tests/data/payments.data.js
+++ b/tests/data/payments.data.js
@@ -1,5 +1,21 @@
 export const PAYMENTSLOCATORS = {
     
+    //Table list elements
+    table: {
+        list: 'payment-cart-list',
+        listItem: 'listitem',
+
+        productName: 'payment-item-name-',
+        productDetails: 'payment-item-quantity-price-',
+        productQuantity: 'payment-item-quantity-',
+
+        productPrice: 'payment-item-price-value-',
+        productTotalPrice: 'payment-item-total-value-',
+     
+    },
+
+    paymentTotalPrice: 'payment-total-value',
+
     // Input-boxes
     paymentMethods: {
         mbway: 'payment-method-label-MBWay',

--- a/tests/pages/cart.page.js
+++ b/tests/pages/cart.page.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { STORELABELS, STORELOCATORS } from '../data/storeMenu.data';
+import { STORELOCATORS } from '../data/storeMenu.data';
 import { CARTLOCATORS } from '../data/cart.data';
 import { PAYMENTSLOCATORS } from '../data/payments.data';
 

--- a/tests/pages/catalog.page.js
+++ b/tests/pages/catalog.page.js
@@ -19,6 +19,11 @@ export class CatalogPage {
 
     }
 
+    // An alternative aproach to list index (not so dynamic and dependent on the product insert sequence and its place on the list)
+    quantity(index) {
+        return this.page.getByTestId('catalog-item-quantity-' + index);
+    }
+
     async addProductToCart(product) {
 
         const initialQuantity = Number((await this.productQuantity(product).textContent()).replace(' units', ''));

--- a/tests/pages/orders.page.js
+++ b/tests/pages/orders.page.js
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+import { STORELOCATORS } from '../data/storeMenu.data';
+import { ORDERSLOCATORS } from '../data/orders.data';
+
+export class OrdersPage {
+    constructor(page) {
+        this.page = page;
+
+        this.ordersTab = page.getByTestId(STORELOCATORS.orders.tab);
+        this.ordersTitle = page.getByTestId(STORELOCATORS.orders.title);
+
+        this.table = page.getByTestId(PAYMENTSLOCATORS.table.list);
+        this.tableListItems = this.table.getByRole(PAYMENTSLOCATORS.table.listItem);
+        // this.tableProduct = (product) => this.tableListItems.filter({ hasText: `${product}` });
+
+    }
+
+
+
+}

--- a/tests/pages/payments.page.js
+++ b/tests/pages/payments.page.js
@@ -1,34 +1,94 @@
 import { test, expect } from '@playwright/test';
 import { PAYMENTSLOCATORS } from "../data/payments.data";
-import { STORELABELS, STORELOCATORS } from '../data/storeMenu.data';
+import { STORELOCATORS } from '../data/storeMenu.data';
 import { ORDERSLOCATORS } from '../data/orders.data';
 
-export class PaymentPage{
-    constructor(page){
+export class PaymentPage {
+    constructor(page) {
         this.page = page;
+
+        this.paymentsTab = page.getByTestId(STORELOCATORS.payments.tab);
+        this.paymentsTitle = page.getByTestId(STORELOCATORS.payments.title);
+
+        this.table = page.getByTestId(PAYMENTSLOCATORS.table.list);
+        this.tableListItems = this.table.getByRole(PAYMENTSLOCATORS.table.listItem);
+        this.tableProduct = (product) => this.tableListItems.filter({ hasText: `${product}` });
+
+        this.productName = (product) => this.tableProduct(product).locator("[data-testid^=" + PAYMENTSLOCATORS.table.productName + "]");
+
+        this.productDetails = (product) => this.tableProduct(product).locator("[data-testid^=" + PAYMENTSLOCATORS.table.productDetails + "]");
+        this.productQuantity = (product) => this.productDetails(product).locator("[data-testid^=" + PAYMENTSLOCATORS.table.productQuantity + "]");
+
+        this.productPrice = (product) => this.productDetails(product).locator("[data-testid^=" + PAYMENTSLOCATORS.table.productPrice + "]");
+        this.productTotalPrice = (product) => this.tableProduct(product).locator("[data-testid^=" + PAYMENTSLOCATORS.table.productTotalPrice + "]");
+
+        this.paymentTotalPrice = page.getByTestId(PAYMENTSLOCATORS.paymentTotalPrice);
         this.confirmPaymentButton = page.getByTestId(PAYMENTSLOCATORS.confirmPaymentButton);
     }
 
-    async selectPaymentMethod(paymentMethodType){
+    async validateIfProductExistsInPayments(product) {
+
+        await test.step('Validate if the product exists in payments page', async () => {
+
+            // Get fields from the table row.
+            await expect(this.productName(product.name)).toHaveText(product.name);
+
+            const productQuantity = await this.productQuantity(product.name).textContent();
+            await expect(productQuantity).toBe(product.addedQuantity);
+
+            const productPrice = await this.productPrice(product.name).textContent();
+            await expect(productPrice).toBe(product.price);
+
+            const productTotalPrice = parseFloat(await this.productTotalPrice(product.name).textContent());
+            await expect(parseFloat(productTotalPrice).toFixed(2)).toBe(parseFloat(productQuantity * productPrice).toFixed(2));
+        });
+    }
+
+    async validateProductListExistsInPayments(productList) {
+        await test.step('Validate if product list exists in payments page', async () => {
+            for (const product of productList) {
+                if (product.addedQuantity > 0) {
+                    await this.validateIfProductExistsInPayments(product);
+                }
+            }
+        });
+    }
+
+    async validateTotalPaymentSummary() {
+
+        await test.step('Validate if the total payment price is correctly calculated', async () => {
+
+            let totalPaymentPrice = parseFloat('0.00');
+
+            const count = await this.tableListItems.count();
+            for (let i = 0; i < count; ++i) {
+                const val = parseFloat(await this.tableListItems.locator("[data-testid^=" + PAYMENTSLOCATORS.table.productTotalPrice + i + "]").textContent()).toFixed(2);
+                totalPaymentPrice = (+totalPaymentPrice + +parseFloat(val)).toFixed(2)
+            }
+            await expect(parseFloat(await this.paymentTotalPrice.textContent()).toFixed(2)).toBe(parseFloat(totalPaymentPrice).toFixed(2));
+        });
+    }
+
+    async selectPaymentMethod(paymentMethodType) {
         await test.step(`Select Payment Type: ${paymentMethodType}`, async () => {
             const paymentLocatorID = PAYMENTSLOCATORS.paymentMethods[paymentMethodType];
             await this.page.getByTestId(paymentLocatorID).click();
         });
     }
 
-    async clickConfirmPaymentButton(){
+    async clickConfirmPaymentButton() {
         await test.step('Click on "Confirm Payment" button', async () => {
             await this.confirmPaymentButton.click();
         });
     }
 
-    async validateRedirectToOrdersPage(){
+    async validateRedirectToOrdersPage() {
         await test.step('Validate Redirect to Orders page', async () => {
             await expect(this.page.getByRole('heading', { name: ORDERSLOCATORS.labels.pageTitle })).toBeVisible();
         });
     }
 
-    async clickConfirmPaymentWithoutSelectingMethod(){
+    async clickConfirmPaymentWithoutSelectingMethod() {
         await test.step('Click on "Confirm Payment" button without selecting a payment method', async () => {
             this.page.once('dialog', async dialog => {
                 expect(dialog.message()).toBe(PAYMENTSLOCATORS.labels.alertMessage);
@@ -39,5 +99,5 @@ export class PaymentPage{
         });
     }
 
-    
+
 }

--- a/tests/pages/store.page.js
+++ b/tests/pages/store.page.js
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { CatalogPage } from './catalog.page';
+import { CartPage } from './cart.page';
+import { StoreMenuPage } from './storeMenu.page';
+import { InventoryPage } from './inventory.page';
+import { PaymentPage } from './payments.page';
+
+export class StorePage {
+    constructor(page) {
+        this.page = page;
+
+        this.storeMenuPage = new StoreMenuPage(page);
+        this.inventoryPage = new InventoryPage(page);
+        this.catalogPage = new CatalogPage(page);
+        this.cartPage = new CartPage(page);
+        this.paymentsPage = new PaymentPage(page);
+    }
+
+    async addProductFromCatalogToCart(product) {
+        await test.step('Add single product from database to cart', async () => {
+            await this.storeMenuPage.navigateToInventoryTab();
+            await this.inventoryPage.addAndValidateProduct(product);
+
+            await this.storeMenuPage.navigateToCatalogTab();
+            await this.catalogPage.addProductToCart(product.name);
+
+            await this.storeMenuPage.navigateToCartTab();
+            await this.cartPage.validateProductSuccessfullyAddedtoCart(product);
+        });
+    }
+
+    async addAndValidateDataProductListToCart(productList) {
+        await test.step('Add product list from database to cart', async () => {
+            await this.storeMenuPage.navigateToInventoryTab();
+            await this.inventoryPage.addMultipleProducts(productList);
+
+            await this.storeMenuPage.navigateToCatalogTab();
+            await this.catalogPage.addProductListToCart(productList);
+
+            await this.storeMenuPage.navigateToCartTab();
+            await this.cartPage.validateProductListAddedtoCart(productList);
+            await this.cartPage.validateTotalCartPrice();
+        });
+    }
+
+    async addAndValidatePaymentSummary(productList) {
+        await test.step('Add and validate product list from database to payments page', async () => {
+            await this.addAndValidateDataProductListToCart(productList);
+            await this.storeMenuPage.navigateToPaymentsTab();
+            await this.paymentsPage.validateProductListExistsInPayments(productList);
+            await this.paymentsPage.validateTotalPaymentSummary();
+        });
+    }
+
+}

--- a/tests/specs/cart.spec.js
+++ b/tests/specs/cart.spec.js
@@ -1,9 +1,10 @@
 import { test } from '@playwright/test';
 import { StoreMenuPage } from '../pages/storeMenu.page'; 
-import { CartPage } from '../pages/cart.pages';
+import { CartPage } from '../pages/cart.page';
 import { STOREPRODUCTS } from '../data/storeMenu.data';
 import { InventoryPage } from '../pages/inventory.page';
 import { CatalogPage } from '../pages/catalog.page';
+import { StorePage } from '../pages/store.page';
 
 test.describe('Cart section', () => {
 
@@ -13,18 +14,17 @@ test.describe('Cart section', () => {
         await storeMenuPage.navigateToCartTab();
     });
 
-    /**
-     * Scenario 1: Add scenario here
+     /**
+     * Scenario 1: Display cart items and totals in cart page
      * 
-     * Given
-     * When
-     * And
-     * Then
-     * And
+     * Given I have added items to the cart
+     * When  I visit the Cart page
+     * Then  each item name, quantity, and subtotal should be displayed
+     * And   the total amount should be correctly calculated.
     */
-    test('Add Cart test here', async ({ page }) => {
-        const storeMenuPage = new StoreMenuPage(page);
-        // await storeMenuPage.navigateToHomeTab();
+    test('Display cart items and totals in cart page', async ({ page }) => {
+        const storePage = new StorePage(page);
+        await storePage.addAndValidateDataProductListToCart(STOREPRODUCTS);
     });
 
     /**

--- a/tests/specs/catalog.spec.js
+++ b/tests/specs/catalog.spec.js
@@ -1,6 +1,8 @@
 import { test } from '@playwright/test';
+import { STOREPRODUCTS } from '../data/storeMenu.data';
 import { StoreMenuPage } from '../pages/storeMenu.page'; 
 import { CatalogPage } from '../pages/catalog.page';
+import { StorePage } from '../pages/store.page';
 
 
 test.describe('Catalog section', () => {
@@ -12,7 +14,22 @@ test.describe('Catalog section', () => {
     });
 
     /**
-     * Scenario 1: Prevent adding out-of-stock items
+     * Scenario 1: Add an item to the cart from the catalog
+     * 
+     * Given I am on the Catalog page
+     * When  the item has quantity available
+     * And   I click "Add to Cart"
+     * Then  the item quantity should decrease in the Catalog
+     * And   the item should appear in the Cart page
+    */
+    test('Add item to cart from catalog', async ({ page }) => {
+        const storePage = new StorePage(page);
+        const product = STOREPRODUCTS[0];
+        await storePage.addProductFromCatalogToCart(product);
+    });
+
+    /**
+     * Scenario 2: Prevent adding out-of-stock items
      *
      * Given an item has quantity 0
      * Then the button should display "Out of Stock"

--- a/tests/specs/payments.spec.js
+++ b/tests/specs/payments.spec.js
@@ -3,9 +3,10 @@ import { StoreMenuPage } from '../pages/storeMenu.page';
 import { PaymentPage } from '../pages/payments.page';
 import { InventoryPage } from '../pages/inventory.page';
 import { CatalogPage } from '../pages/catalog.page';
-import { CartPage } from '../pages/cart.pages';
+import { CartPage } from '../pages/cart.page';
 import { PAYMENTSLOCATORS } from '../data/payments.data';
 import { STOREPRODUCTS } from '../data/storeMenu.data';
+import { StorePage } from '../pages/store.page';
 
 test.describe('Payments section', () => {
 
@@ -15,18 +16,18 @@ test.describe('Payments section', () => {
         await storeMenuPage.navigateToPaymentsTab();
     });
 
-    /**
-     * Scenario 1: Add scenario here
+     /**
+     * Scenario 1: Validate payment summary
      * 
-     * Given
-     * When
-     * And
-     * Then
-     * And
+     * Given I have items in the cart
+     * When  I navigate to the Payments page
+     * Then  I should see a summary with name, quantity, and subtotal
+     * And   I should see the total amount at the bottom.
+     * 
     */
-    test('Add Payments test here', async ({ page }) => {
-        const storeMenuPage = new StoreMenuPage(page);
-        // await storeMenuPage.navigateToHomeTab();
+    test('Display cart items and totals in cart page', async ({ page }) => {
+        const storePage = new StorePage(page);
+        await storePage.addAndValidatePaymentSummary(STOREPRODUCTS);
     });
 
     /**

--- a/tests/specs/storeFlow.spec.js
+++ b/tests/specs/storeFlow.spec.js
@@ -1,9 +1,5 @@
 import { test } from '@playwright/test';
-import { STOREPRODUCTS } from '../data/storeMenu.data';
 import { StoreMenuPage } from '../pages/storeMenu.page';
-import { InventoryPage } from '../pages/inventory.page';
-import { CatalogPage } from '../pages/catalog.page';
-import { CartPage } from '../pages/cart.pages';
 
 test.describe('Integration tests between store pages', () => {
 
@@ -13,52 +9,4 @@ test.describe('Integration tests between store pages', () => {
         await storeMenuPage.navigateToInventoryTab();
     });
 
-    /**
-     * Scenario 1: Add an item to the cart from the catalog
-     * 
-     * Given I am on the Catalog page
-     * When  the item has quantity available
-     * And   I click "Add to Cart"
-     * Then  the item quantity should decrease in the Catalog
-     * And   the item should appear in the Cart page
-    */
-    test('Add item to cart from catalog', async ({ page }) => {
-        const storeMenuPage = new StoreMenuPage(page);
-        const inventoryPage = new InventoryPage(page);
-        const catalogPage = new CatalogPage(page);
-        const cartPage = new CartPage(page);
-
-        const product = STOREPRODUCTS[0];
-        await inventoryPage.addAndValidateProduct(product);
-
-        await storeMenuPage.navigateToCatalogTab();
-        await catalogPage.addProductToCart(product.name);
-
-        await storeMenuPage.navigateToCartTab();
-        await cartPage.validateProductSuccessfullyAddedtoCart(product);
-    });
-
-    /**
-     * Scenario 2: Display cart items and totals in cart page
-     * 
-     * Given I have added items to the cart
-     * When  I visit the Cart page
-     * Then  each item name, quantity, and subtotal should be displayed
-     * And   the total amount should be correctly calculated.
-    */
-    test('Display cart items and totals in cart page', async ({ page }) => {
-        const storeMenuPage = new StoreMenuPage(page);
-        const inventoryPage = new InventoryPage(page);
-        const catalogPage = new CatalogPage(page);
-        const cartPage = new CartPage(page);
-
-        await inventoryPage.addMultipleProducts(STOREPRODUCTS);
-        await storeMenuPage.navigateToCatalogTab();
-
-        await catalogPage.addProductListToCart(STOREPRODUCTS);
-        await storeMenuPage.navigateToCartTab();
-
-        await cartPage.validateProductListAddedtoCart(STOREPRODUCTS);
-        await cartPage.validateTotalCartPrice();
-    });
 });


### PR DESCRIPTION
- Realocate StoreFlow.spec.js page test for Catalog and Cart classes;
- Optimize the tests in spec pages by creating functions in page.js classes;
- Create the test case for the following test scenario in the Payments page:

```
Scenario: Validate payment summary

Given I have items in the cart
When  I navigate to the Payment page
Then  I should see a summary with name, quantity, and subtotal
And   I should see the total amount at the bottom
````
